### PR TITLE
Fixed #34 - Enable parameterized gradle builds

### DIFF
--- a/couchbase-lite-android-liteserv/build.gradle
+++ b/couchbase-lite-android-liteserv/build.gradle
@@ -3,7 +3,7 @@
  */
 apply plugin: 'maven'
 
-final String DEF_VERSION = "0.0.0-688"
+final String DEF_VERSION = "1.2.1"
 final String DEF_STORAGEE = "SQLite" // SQLite or ForestDB
 
 println System.getProperty('version', DEF_VERSION)

--- a/couchbase-lite-android-liteserv/build.gradle
+++ b/couchbase-lite-android-liteserv/build.gradle
@@ -1,15 +1,19 @@
-
+/**
+ * ./gradlew -Dversion=0.0.0-688 -Dstorage=SQLite|ForestDB <task>
+ */
 apply plugin: 'maven'
 
-def couchbaseMavenRepo = 'http://files.couchbase.com/maven2/'
+final String DEF_VERSION = "0.0.0-688"
+final String DEF_STORAGEE = "SQLite" // SQLite or ForestDB
 
-def localMavenRepo     = System.getProperty('MAVEN_LOCAL_REPO') == null ?
-                         'file://' + new File(System.getProperty('user.home'), '.m2/repository').absolutePath :
-                         'file://' + System.getProperty('MAVEN_LOCAL_REPO')
+println System.getProperty('version', DEF_VERSION)
+println System.getProperty('storage', DEF_STORAGEE)
+
 repositories {
-    mavenCentral()
-    maven { url couchbaseMavenRepo }
-    maven { url localMavenRepo     }
+    jcenter()
+    maven {
+        url 'http://files.couchbase.com/maven2/'
+    }
 }
 
 buildscript {
@@ -17,50 +21,19 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.0.0'
+        classpath 'com.android.tools.build:gradle:1.3.0'
     }
 }
 apply plugin: 'android'
 
-
-def buildLiteServWithArtifacts = System.getProperty("buildLiteServWithArtifacts")
-
 dependencies {
-
     compile 'com.android.support:support-v4:13.0.+'
-
     compile fileTree(dir: 'libs', include: '*.jar')
 
-    compile 'com.couchbase.lite:couchbase-lite-android:0.0.0-688'
-    compile 'com.couchbase.lite:couchbase-lite-android-forestdb:0.0.0-688'
-    compile 'com.couchbase.lite:couchbase-lite-java-javascript:0.0.0-688'
-    compile 'com.couchbase.lite:couchbase-lite-java-listener:0.0.0-688'
-
-    /*
-    compile buildLiteServWithArtifacts == null ?
-            project(':libraries:couchbase-lite-java-core') :
-            'com.couchbase.lite:couchbase-lite-java-core:' + System.getenv("MAVEN_UPLOAD_VERSION")
-
-    compile buildLiteServWithArtifacts == null ?
-            project(':libraries:couchbase-lite-java-forestdb') :
-            'com.couchbase.lite:couchbase-lite-java-forestdb:' + System.getenv("MAVEN_UPLOAD_VERSION")
-
-    compile buildLiteServWithArtifacts == null ?
-            project(':libraries:couchbase-lite-android') :
-            'com.couchbase.lite:couchbase-lite-android:' + System.getenv("MAVEN_UPLOAD_VERSION")
-
-    compile buildLiteServWithArtifacts == null ?
-            project(':libraries:couchbase-lite-java-javascript') :
-            'com.couchbase.lite:couchbase-lite-java-javascript:' + System.getenv("MAVEN_UPLOAD_VERSION")
-
-    compile buildLiteServWithArtifacts == null ?
-            project(':libraries:couchbase-lite-java-listener') :
-            'com.couchbase.lite:couchbase-lite-java-listener:' + System.getenv("MAVEN_UPLOAD_VERSION")
-
-    compile buildLiteServWithArtifacts == null ?
-            project(':libraries:couchbase-lite-java-native:sqlite-default') :
-            'com.couchbase.lite:couchbase-lite-android-sqlite-default' + System.getenv("MAVEN_UPLOAD_VERSION")
-    */
+    compile 'com.couchbase.lite:couchbase-lite-android:' + System.getProperty('VERSION', DEF_VERSION)
+    compile 'com.couchbase.lite:couchbase-lite-android-forestdb:' + System.getProperty('VERSION', DEF_VERSION)
+    compile 'com.couchbase.lite:couchbase-lite-java-javascript:' + System.getProperty('VERSION', DEF_VERSION)
+    compile 'com.couchbase.lite:couchbase-lite-java-listener:' + System.getProperty('VERSION', DEF_VERSION)
 }
 
 android {
@@ -70,6 +43,7 @@ android {
     defaultConfig {
         minSdkVersion 9
         targetSdkVersion 22
+        manifestPlaceholders = [storage: System.getProperty('storage', DEF_STORAGEE)]
     }
 
     lintOptions {
@@ -83,5 +57,4 @@ android {
         exclude 'META-INF/LICENSE'
         exclude 'META-INF/NOTICE'
     }
-
 }

--- a/couchbase-lite-android-liteserv/src/main/AndroidManifest.xml
+++ b/couchbase-lite-android-liteserv/src/main/AndroidManifest.xml
@@ -9,15 +9,16 @@
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"
         android:theme="@style/AppTheme" >
+
+        <meta-data android:name="storage" android:value="${storage}" />
+
         <activity
             android:name="com.couchbase.liteservandroid.MainActivity"
             android:label="@string/app_name" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
     </application>
-
 </manifest>

--- a/couchbase-lite-android-liteserv/src/main/java/com/couchbase/liteservandroid/MainActivity.java
+++ b/couchbase-lite-android-liteserv/src/main/java/com/couchbase/liteservandroid/MainActivity.java
@@ -1,6 +1,8 @@
 package com.couchbase.liteservandroid;
 
 import android.app.Activity;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageManager;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.Menu;
@@ -19,27 +21,31 @@ import com.couchbase.lite.listener.LiteListener;
 import java.io.IOException;
 
 public class MainActivity extends Activity {
-
     private static final int DEFAULT_LISTEN_PORT = 5984;
     private static final String DATABASE_NAME = "cblite-test";
     private static final String LISTEN_PORT_PARAM_NAME = "listen_port";
-
     private static final String LISTEN_LOGIN_PARAM_NAME = "username";
     private static final String LISTEN_PASSWORD_PARAM_NAME = "password";
-
-    private static final String STORAGE_TYPE_PARAM_NAME = "storage_type";
-    private static final String STORAGE_TYPE_FORESTDB = "ForestDB";
-    private static final String STORAGE_TYPE_SQLITE = "SQLite";
-
-
     public static String TAG = "LiteServ";
+
     private Credentials allowedCredentials;
-    private String storageType = STORAGE_TYPE_SQLITE;
+    private String storageType = null;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
+
+        // storage
+        ApplicationInfo info = null;
+        try {
+            info = getApplicationContext().getPackageManager().getApplicationInfo(getApplicationContext().getPackageName(), PackageManager.GET_META_DATA);
+            storageType = (String)info.metaData.get("storage");
+        } catch (PackageManager.NameNotFoundException e) {
+            Log.e(TAG, "failed to obtain meta data from AndroidManifest.xml", e);
+            storageType = "sqlite";
+        }
+        Log.i(TAG, "storageType=" + storageType);
 
         // Register the JavaScript view compiler
         View.setCompiler(new JavaScriptViewCompiler());
@@ -50,7 +56,7 @@ public class MainActivity extends Activity {
             showListenPort(port);
             showListenCredentials();
         } catch (Exception e) {
-            TextView listenPortTextView = (TextView)findViewById(R.id.listen_port_textview);
+            TextView listenPortTextView = (TextView) findViewById(R.id.listen_port_textview);
             listenPortTextView.setText(String.format("Error starting LiteServ"));
             Log.e(TAG, "Error starting LiteServ", e);
         }
@@ -58,12 +64,12 @@ public class MainActivity extends Activity {
 
     private void showListenPort(int listenPort) {
         Log.d(TAG, "listenPort: " + listenPort);
-        TextView listenPortTextView = (TextView)findViewById(R.id.listen_port_textview);
+        TextView listenPortTextView = (TextView) findViewById(R.id.listen_port_textview);
         listenPortTextView.setText(String.format("Listening on port: %d.  Db: %s Storage: %s", listenPort, DATABASE_NAME, storageType));
     }
 
     private void showListenCredentials() {
-        TextView listenCredentialsTextView = (TextView)findViewById(R.id.listen_credentials_textview);
+        TextView listenCredentialsTextView = (TextView) findViewById(R.id.listen_credentials_textview);
         String credentialsDisplay = String.format(
                 "login: %s password: %s",
                 allowedCredentials.getLogin(),
@@ -71,43 +77,32 @@ public class MainActivity extends Activity {
         );
         Log.v(TAG, credentialsDisplay);
         listenCredentialsTextView.setText(credentialsDisplay);
-
     }
 
     private int startCBLListener(int suggestedListenPort) throws IOException, CouchbaseLiteException {
-
         Manager manager = startCBLite();
         startDatabase(manager, DATABASE_NAME);
 
-        if (getLogin()!=null && getPassword()!=null){
-            if(getLogin().equals("none") && getPassword().equals("none")) {
+        if (getLogin() != null && getPassword() != null) {
+            if (getLogin().equals("none") && getPassword().equals("none")) {
                 allowedCredentials = new Credentials("", "");
             } else {
                 allowedCredentials = new Credentials(getLogin(), getPassword());
             }
-        }  else {
+        } else {
             allowedCredentials = new Credentials();
         }
 
         LiteListener listener = new LiteListener(manager, suggestedListenPort, allowedCredentials);
-
         int port = listener.getListenPort();
         Thread thread = new Thread(listener);
         thread.start();
-
         return port;
     }
 
     protected Manager startCBLite() throws IOException {
-        Manager manager;
-        manager = new Manager(new AndroidContext(this), Manager.DEFAULT_OPTIONS);
-        this.storageType = getStorageType();
-        if (storageType != null && storageType.compareToIgnoreCase(STORAGE_TYPE_FORESTDB) == 0)
-            this.storageType = Manager.FORESTDB_STORAGE;
-        else
-            this.storageType = Manager.SQLITE_STORAGE;
-        Log.i(TAG, "storageType: " + this.storageType);
-        manager.setStorageType(this.storageType);
+        Manager manager = new Manager(new AndroidContext(this), Manager.DEFAULT_OPTIONS);
+        manager.setStorageType(storageType);
         return manager;
     }
 
@@ -128,15 +123,10 @@ public class MainActivity extends Activity {
         return getIntent().getStringExtra(LISTEN_PASSWORD_PARAM_NAME);
     }
 
-    private String getStorageType() {
-        return getIntent().getStringExtra(STORAGE_TYPE_PARAM_NAME);
-    }
-
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
         // Inflate the menu; this adds items to the action bar if it is present.
         getMenuInflater().inflate(R.menu.main, menu);
         return true;
     }
-    
 }


### PR DESCRIPTION
- Parameter should be set like `./gradlew -Dversion=0.0.0-688 -Dstorage=SQLite | ForestDB <task>`
- For storage type, gradle set value in AndroidManifest.xml, at runtime, LiteServ gets storage type from Manifest.xml.