### PR TITLE
Fixed https://github.com/couchbase/couchbase-lite-java-core/issues/1366

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,16 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
+buildscript {
+    repositories {
+        jcenter()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:2.1.3'
+
+        // NOTE: Do not place your application dependencies here; they belong
+        // in the individual module build.gradle files
+    }
+}
+
 allprojects {
     repositories {
         jcenter()

--- a/couchbase-lite-android-liteserv/build.gradle
+++ b/couchbase-lite-android-liteserv/build.gradle
@@ -1,42 +1,31 @@
 /**
- * ./gradlew -Dversion=0.0.0-688 -Dstorage=SQLite|ForestDB -Ddbpassword={dbname}:{password},... <task>
+ * ./gradlew -Dversion=0.0.0-688 -Dfeature=basic|full -Dstorage=SQLite|ForestDB -Ddbpassword={dbname}:{password},... <task>
  */
-apply plugin: 'maven'
-
-final String DEF_VERSION = "1.2.1"
+final String DEF_VERSION = "1.3.0"
+final String DEF_FEATURE = "basic"
 final String DEF_STORAGEE = "SQLite" // SQLite or ForestDB
 final String DEF_DBPASSWORD = ""; // null or empty -> no encryption password, with password -> enc
 
 println "version=" + System.getProperty('version', DEF_VERSION)
+println "feature=" + System.getProperty('feature', DEF_FEATURE)
 println "storage=" + System.getProperty('storage', DEF_STORAGEE)
 println "dbpassword=" + System.getProperty('dbpassword', DEF_DBPASSWORD)
 
-repositories {
-    jcenter()
-    maven {
-        url 'http://files.couchbase.com/maven2/'
-    }
-}
-
-buildscript {
-    repositories {
-        mavenCentral()
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:1.3.0'
-    }
-}
-apply plugin: 'android'
+apply plugin: 'com.android.application'
 
 dependencies {
     compile 'com.android.support:support-v4:13.0.+'
     compile fileTree(dir: 'libs', include: '*.jar')
 
     compile 'com.couchbase.lite:couchbase-lite-android:' + System.getProperty('version', DEF_VERSION)
-    compile 'com.couchbase.lite:couchbase-lite-android-forestdb:' + System.getProperty('version', DEF_VERSION)
-    compile 'com.couchbase.lite:couchbase-lite-android-sqlcipher:' + System.getProperty('version', DEF_VERSION)
     compile 'com.couchbase.lite:couchbase-lite-java-javascript:' + System.getProperty('version', DEF_VERSION)
     compile 'com.couchbase.lite:couchbase-lite-java-listener:' + System.getProperty('version', DEF_VERSION)
+
+    // basic -> SQLite, full -> with SQLCipher & ForestDB
+    if (System.getProperty('feature', DEF_FEATURE).equalsIgnoreCase("full")) {
+        compile 'com.couchbase.lite:couchbase-lite-android-forestdb:' + System.getProperty('version', DEF_VERSION)
+        compile 'com.couchbase.lite:couchbase-lite-android-sqlcipher:' + System.getProperty('version', DEF_VERSION)
+    }
 }
 
 android {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Nov 24 12:48:44 PST 2014
+#Fri Aug 19 17:08:32 PDT 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://downloads.gradle.org/distributions/gradle-2.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip


### PR DESCRIPTION
Need SQLite build for LiteServ in CI

- Added feature parameter to build.gradle to choose basic or full, basic -> SQLite, full -> with SQLCipher and ForestDB.
- update gradle version
- update build.gradle